### PR TITLE
Add functionality for generated cpu-only queries on time-series collections

### DIFF
--- a/cmd/tsbs_generate_queries/databases/mongo/devops-naive.go
+++ b/cmd/tsbs_generate_queries/databases/mongo/devops-naive.go
@@ -8,6 +8,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 
 	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/uses/devops"
+	"github.com/timescale/tsbs/internal/utils"
 	"github.com/timescale/tsbs/query"
 )
 
@@ -121,10 +122,11 @@ func (d *NaiveDevops) GroupByTimeAndPrimaryTag(qi query.Query, numMetrics int) {
 			"$project": bson.M{
 				"_id": 0,
 				"time_bucket": bson.M{
-					"$dateSubtract": bson.M{
-						"startDate": "$time",
-						"unit":      "second",
-						"amount":    bson.M{"$second": bson.M{"date": "$time"}},
+					"$dateFromParts": bson.M{
+						"year":  bson.M{"$year": "$time"},
+						"month": bson.M{"$month": "$time"},
+						"day":   bson.M{"$dayOfMonth": "$time"},
+						"hour":  bson.M{"$hour": "$time"},
 					},
 				},
 				"tags.hostname": 1,
@@ -159,4 +161,253 @@ func (d *NaiveDevops) GroupByTimeAndPrimaryTag(qi query.Query, numMetrics int) {
 	q.BsonDoc = pipelineQuery
 	q.CollectionName = []byte("point_data")
 	q.HumanDescription = []byte(fmt.Sprintf("%s: %s (%s)", humanLabel, interval.StartString(), q.CollectionName))
+}
+
+// MaxAllCPU selects the MAX of all metrics under 'cpu' per hour for nhosts hosts,
+// e.g. in pseudo-SQL:
+//
+// SELECT MAX(metric1), ..., MAX(metricN)
+// FROM cpu WHERE (hostname = '$HOSTNAME_1' OR ... OR hostname = '$HOSTNAME_N')
+// AND time >= '$HOUR_START' AND time < '$HOUR_END'
+// GROUP BY hour ORDER BY hour
+func (d *NaiveDevops) MaxAllCPU(qi query.Query, nHosts int) {
+	interval := d.Interval.MustRandWindow(devops.MaxAllDuration)
+	hostnames, err := d.GetRandomHosts(nHosts)
+	panicIfErr(err)
+	metrics := devops.GetAllCPUMetrics()
+
+	pipelineQuery := []bson.M{
+		{
+			"$match": bson.M{
+				"measurement": "cpu",
+				"tags.hostname": bson.M{
+					"$in": hostnames,
+				},
+				"time": bson.M{
+					"$gte": interval.Start(),
+					"$lt":  interval.End(),
+				},
+			},
+		},
+		{
+			"$project": bson.M{
+				"_id": 0,
+				"time_bucket": bson.M{
+					"$dateFromParts": bson.M{
+						"year":  bson.M{"$year": "$time"},
+						"month": bson.M{"$month": "$time"},
+						"day":   bson.M{"$dayOfMonth": "$time"},
+						"hour":  bson.M{"$hour": "$time"},
+					},
+				},
+			},
+		},
+	}
+	projectMap := pipelineQuery[1]["$project"].(bson.M)
+	for _, metric := range metrics {
+		projectMap[metric] = 1
+	}
+
+	group := bson.M{
+		"$group": bson.M{
+			"_id": "$time_bucket",
+		},
+	}
+	resultMap := group["$group"].(bson.M)
+	for _, metric := range metrics {
+		resultMap["max_"+metric] = bson.M{"$max": "$" + metric}
+	}
+	pipelineQuery = append(pipelineQuery, group)
+	pipelineQuery = append(pipelineQuery, bson.M{"$sort": bson.M{"_id": 1}})
+
+	humanLabel := devops.GetMaxAllLabel("Mongo", nHosts)
+	q := qi.(*query.Mongo)
+	q.HumanLabel = []byte(humanLabel)
+	q.BsonDoc = pipelineQuery
+	q.CollectionName = []byte("point_data")
+	q.HumanDescription = []byte(fmt.Sprintf("%s: %s", humanLabel, interval.StartString()))
+}
+
+// HighCPUForHosts populates a query that gets CPU metrics when the CPU has high
+// usage between a time period for a number of hosts (if 0, it will search all hosts),
+// e.g. in pseudo-SQL:
+//
+// SELECT * FROM cpu
+// WHERE usage_user > 90.0
+// AND time >= '$TIME_START' AND time < '$TIME_END'
+// AND (hostname = '$HOST' OR hostname = '$HOST2'...)
+func (d *NaiveDevops) HighCPUForHosts(qi query.Query, nHosts int) {
+	interval := d.Interval.MustRandWindow(devops.HighCPUDuration)
+	metrics := devops.GetAllCPUMetrics()
+
+	pipelineQuery := []bson.M{}
+
+	// Must match in the documents that correspond to time, as well as optionally
+	// filter on those with the correct host if nHosts > 0
+	match := bson.M{
+		"$match": bson.M{
+			"measurement": "cpu",
+			"time": bson.M{
+				"$gte": interval.Start(),
+				"$lt":  interval.End(),
+			},
+		},
+	}
+	if nHosts > 0 {
+		hostnames, err := d.GetRandomHosts(nHosts)
+		panicIfErr(err)
+		matchMap := match["$match"].(bson.M)
+		matchMap["tags.hostname"] = bson.M{"$in": hostnames}
+	}
+	pipelineQuery = append(pipelineQuery, match)
+
+	project := bson.M{
+		"$project": bson.M{
+			"_id":  0,
+			"time": 1,
+			"tags": "$tags.hostname",
+		},
+	}
+	projectMap := project["$project"].(bson.M)
+	for _, metric := range metrics {
+		projectMap[metric] = 1
+	}
+	pipelineQuery = append(pipelineQuery, project)
+	pipelineQuery = append(pipelineQuery, bson.M{"$match": bson.M{"usage_user": bson.M{"$gt": 90.0}}})
+
+	humanLabel, err := devops.GetHighCPULabel("Mongo", nHosts)
+	panicIfErr(err)
+	q := qi.(*query.Mongo)
+	q.HumanLabel = []byte(humanLabel)
+	q.BsonDoc = pipelineQuery
+	q.CollectionName = []byte("point_data")
+	q.HumanDescription = []byte(fmt.Sprintf("%s: %s (%s)", humanLabel, interval.StartString(), q.CollectionName))
+}
+
+// LastPointPerHost finds the last row for every host in the dataset
+func (d *NaiveDevops) LastPointPerHost(qi query.Query) {
+	metrics := devops.GetAllCPUMetrics()
+
+	pipelineQuery := []bson.M{
+		{"$match": bson.M{"measurement": "cpu"}},
+		{
+			"$group": bson.M{
+				"_id":       bson.M{"hostname": "$tags.hostname"},
+				"last_time": bson.M{"$max": "$time"},
+			},
+		},
+		{
+			"$group": bson.M{
+				"_id":   bson.M{"last_time": "$last_time"},
+				"hosts": bson.M{"$addToSet": "$_id.hostname"},
+			},
+		},
+		{
+			"$lookup": bson.M{
+				"from": "point_data",
+				"let":  bson.M{"time": "$_id.last_time", "hosts": "$hosts"},
+				"pipeline": []bson.M{
+					{
+						"$match": bson.M{
+							"$expr": bson.M{
+								"$and": []bson.M{
+									{"$eq": []interface{}{"$time", "$$time"}},
+									{"$in": []interface{}{"$tags.hostname", "$$hosts"}},
+									{"$eq": []interface{}{"$measurement", "cpu"}},
+								},
+							},
+						},
+					},
+					{
+						"$project": bson.M{
+							"time":          1,
+							"tags.hostname": 1,
+							"_id":           0,
+						},
+					},
+				},
+				"as": "results",
+			},
+		},
+		{
+			"$unwind": "$results",
+		},
+		{
+			"$project": bson.M{
+				"hostname":    "$results.tags.hostname",
+				"result.time": "$results.time",
+				"_id":         0,
+			},
+		},
+	}
+
+	lookupPipeline := pipelineQuery[3]["$lookup"].(bson.M)["pipeline"]
+	lookupProjectMap := lookupPipeline.([]bson.M)[1]["$project"].(bson.M)
+	projectMap := pipelineQuery[5]["$project"].(bson.M)
+	for _, metric := range metrics {
+		lookupProjectMap[metric] = 1
+		projectMap["result."+metric] = "$results." + metric
+	}
+
+	humanLabel := "Mongo last row per host"
+	q := qi.(*query.Mongo)
+	q.HumanLabel = []byte(humanLabel)
+	q.BsonDoc = pipelineQuery
+	q.CollectionName = []byte("point_data")
+	q.HumanDescription = []byte(fmt.Sprintf("%s", humanLabel))
+}
+
+// GroupByOrderByLimit populates a query.Query that has a time WHERE clause, that groups by a
+// truncated date, orders by that date, and takes a limit, e.g. in pseudo-SQL:
+//
+// SELECT date_trunc('minute', time) AS t, MAX(cpu) FROM cpu
+// WHERE time < '$TIME'
+// GROUP BY t ORDER BY t DESC
+// LIMIT $LIMIT
+func (d *NaiveDevops) GroupByOrderByLimit(qi query.Query) {
+	interval := d.Interval.MustRandWindow(time.Hour)
+	interval, err := utils.NewTimeInterval(d.Interval.Start(), interval.End())
+	if err != nil {
+		panic(err.Error())
+	}
+
+	pipelineQuery := []bson.M{
+		{
+			"$match": bson.M{
+				"measurement": "cpu",
+				"time": bson.M{
+					"$gte": interval.Start(),
+					"$lt":  interval.End(),
+				},
+			},
+		},
+		{
+			"$project": bson.M{
+				"_id": 0,
+				"time_bucket": bson.M{
+					"$dateSubtract": bson.M{
+						"startDate": "$time",
+						"unit":      "second",
+						"amount":    bson.M{"$second": bson.M{"date": "$time"}},
+					},
+				},
+				"field": "$usage_user",
+			},
+		},
+		{
+			"$group": bson.M{
+				"_id":       "$time_bucket",
+				"max_value": bson.M{"$max": "$field"},
+			},
+		},
+		{"$sort": bson.M{"_id": -1}},
+		{"$limit": 5},
+	}
+
+	humanLabel := "Mongo max cpu over last 5 min-intervals (random end)"
+	q := qi.(*query.Mongo)
+	q.HumanLabel = []byte(humanLabel)
+	q.BsonDoc = pipelineQuery
+	q.CollectionName = []byte("point_data")
+	q.HumanDescription = []byte(fmt.Sprintf("%s: %s", humanLabel, interval.EndString()))
 }

--- a/cmd/tsbs_generate_queries/databases/mongo/devops-naive.go
+++ b/cmd/tsbs_generate_queries/databases/mongo/devops-naive.go
@@ -204,6 +204,7 @@ func (d *NaiveDevops) HighCPUForHosts(qi query.Query, nHosts int) {
 				"$gte": interval.Start(),
 				"$lt":  interval.End(),
 			},
+			"usage_user": bson.M{"$gt": 90.0},
 		},
 	}
 	if nHosts > 0 {
@@ -214,7 +215,6 @@ func (d *NaiveDevops) HighCPUForHosts(qi query.Query, nHosts int) {
 	}
 	pipelineQuery = append(pipelineQuery, match)
 	pipelineQuery = append(pipelineQuery, bson.M{"$set": bson.M{"tags": "$tags.hostname"}})
-	pipelineQuery = append(pipelineQuery, bson.M{"$match": bson.M{"usage_user": bson.M{"$gt": 90.0}}})
 
 	humanLabel, err := devops.GetHighCPULabel("Mongo", nHosts)
 	panicIfErr(err)

--- a/cmd/tsbs_generate_queries/databases/mongo/devops-naive.go
+++ b/cmd/tsbs_generate_queries/databases/mongo/devops-naive.go
@@ -217,9 +217,9 @@ func (d *NaiveDevops) HighCPUForHosts(qi query.Query, nHosts int) {
 
 	project := bson.M{
 		"$project": bson.M{
-			"_id":           0,
-			"time":          1,
-			"tags.hostname": 1,
+			"_id":  0,
+			"time": 1,
+			"tags": "$tags.hostname",
 		},
 	}
 	projectMap := project["$project"].(bson.M)
@@ -227,6 +227,7 @@ func (d *NaiveDevops) HighCPUForHosts(qi query.Query, nHosts int) {
 		projectMap[metric] = 1
 	}
 	pipelineQuery = append(pipelineQuery, project)
+	pipelineQuery = append(pipelineQuery, bson.M{"$match": bson.M{"usage_user": bson.M{"$gt": 90.0}}})
 
 	humanLabel, err := devops.GetHighCPULabel("Mongo", nHosts)
 	panicIfErr(err)

--- a/cmd/tsbs_generate_queries/databases/mongo/devops-naive.go
+++ b/cmd/tsbs_generate_queries/databases/mongo/devops-naive.go
@@ -204,7 +204,6 @@ func (d *NaiveDevops) HighCPUForHosts(qi query.Query, nHosts int) {
 				"$gte": interval.Start(),
 				"$lt":  interval.End(),
 			},
-			"usage_user": bson.M{"$gt": 90.0},
 		},
 	}
 	if nHosts > 0 {

--- a/cmd/tsbs_generate_queries/databases/mongo/devops.go
+++ b/cmd/tsbs_generate_queries/databases/mongo/devops.go
@@ -50,14 +50,14 @@ func getTimeFilterPipeline(interval *utils.TimeInterval) []bson.M {
 							"$and": []interface{}{
 								bson.M{
 									"$gte": []interface{}{
-										"$$event.timestamp_ns",
-										interval.StartUnixNano(),
+										"$$event.time",
+										interval.Start(),
 									},
 								},
 								bson.M{
 									"$lt": []interface{}{
-										"$$event.timestamp_ns",
-										interval.EndUnixNano(),
+										"$$event.time",
+										interval.End(),
 									},
 								},
 							},
@@ -107,7 +107,6 @@ func (d *Devops) GroupByTime(qi query.Query, nHosts, numMetrics int, timeRange t
 	metrics, err := devops.GetCPUMetricsSlice(numMetrics)
 	panicIfErr(err)
 	docs := getTimeFilterDocs(interval)
-	bucketNano := time.Minute.Nanoseconds()
 
 	pipelineQuery := []bson.M{
 		{
@@ -134,10 +133,7 @@ func (d *Devops) GroupByTime(qi query.Query, nHosts, numMetrics int, timeRange t
 	pipelineQuery = append(pipelineQuery, bson.M{
 		"$project": bson.M{
 			"time_bucket": bson.M{
-				"$subtract": []interface{}{
-					"$events.timestamp_ns",
-					bson.M{"$mod": []interface{}{"$events.timestamp_ns", bucketNano}},
-				},
+				"$dateTrunc": bson.M{"date": "$events.time", "unit": "minute"},
 			},
 			"events": 1,
 		},
@@ -175,7 +171,6 @@ func (d *Devops) MaxAllCPU(qi query.Query, nHosts int) {
 	hostnames, err := d.GetRandomHosts(nHosts)
 	panicIfErr(err)
 	docs := getTimeFilterDocs(interval)
-	bucketNano := time.Hour.Nanoseconds()
 	metrics := devops.GetAllCPUMetrics()
 
 	pipelineQuery := []bson.M{
@@ -203,10 +198,7 @@ func (d *Devops) MaxAllCPU(qi query.Query, nHosts int) {
 	pipelineQuery = append(pipelineQuery, bson.M{
 		"$project": bson.M{
 			"time_bucket": bson.M{
-				"$subtract": []interface{}{
-					"$events.timestamp_ns",
-					bson.M{"$mod": []interface{}{"$events.timestamp_ns", bucketNano}},
-				},
+				"$dateTrunc": bson.M{"date": "$events.time", "unit": "hour"},
 			},
 			"events": 1,
 		},
@@ -244,7 +236,6 @@ func (d *Devops) GroupByTimeAndPrimaryTag(qi query.Query, numMetrics int) {
 	metrics, err := devops.GetCPUMetricsSlice(numMetrics)
 	panicIfErr(err)
 	docs := getTimeFilterDocs(interval)
-	bucketNano := time.Hour.Nanoseconds()
 
 	pipelineQuery := []bson.M{
 		{
@@ -271,10 +262,7 @@ func (d *Devops) GroupByTimeAndPrimaryTag(qi query.Query, numMetrics int) {
 		{
 			"$project": bson.M{
 				"time_bucket": bson.M{
-					"$subtract": []interface{}{
-						"$events.timestamp_ns",
-						bson.M{"$mod": []interface{}{"$events.timestamp_ns", bucketNano}},
-					},
+					"$dateTrunc": bson.M{"date": "$events.time", "unit": "hour"},
 				},
 				"measurement": 1,
 				"tags":        1,
@@ -419,7 +407,7 @@ func (d *Devops) LastPointPerHost(qi query.Query) {
 							"$and": []interface{}{
 								bson.M{
 									"$gte": []interface{}{
-										"$$event.timestamp_ns",
+										"$$event.time",
 										0,
 									},
 								},
@@ -458,7 +446,6 @@ func (d *Devops) GroupByOrderByLimit(qi query.Query) {
 		panic(err.Error())
 	}
 	docs := getTimeFilterDocs(interval)
-	bucketNano := time.Minute.Nanoseconds()
 
 	pipelineQuery := []bson.M{
 		{
@@ -483,10 +470,7 @@ func (d *Devops) GroupByOrderByLimit(qi query.Query) {
 		{
 			"$project": bson.M{
 				"time_bucket": bson.M{
-					"$subtract": []interface{}{
-						"$events.timestamp_ns",
-						bson.M{"$mod": []interface{}{"$events.timestamp_ns", bucketNano}},
-					},
+					"$dateTrunc": bson.M{"date": "$events.time", "unit": "minute"},
 				},
 				"field": "$events.usage_user",
 			},

--- a/cmd/tsbs_run_queries_mongo/main.go
+++ b/cmd/tsbs_run_queries_mongo/main.go
@@ -48,7 +48,7 @@ func init() {
 	config.AddToFlagSet(pflag.CommandLine)
 
 	pflag.String("url", "mongodb://localhost:27017", "Daemon URL.")
-	pflag.Duration("read-timeout", 30*time.Second, "Timeout value for individual queries")
+	pflag.Duration("read-timeout", 300*time.Second, "Timeout value for individual queries")
 
 	pflag.Parse()
 
@@ -92,7 +92,7 @@ func (p *processor) ProcessQuery(q query.Query, _ bool) ([]*query.Stat, error) {
 	mq := q.(*query.Mongo)
 	start := time.Now().UnixNano()
 
-	cursor, err := p.collection.Aggregate(context.Background(), mq.BsonDoc)
+	cursor, err := p.collection.Aggregate(context.Background(), mq.BsonDoc, mq.Opts)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/tsbs_run_queries_mongo/main.go
+++ b/cmd/tsbs_run_queries_mongo/main.go
@@ -42,6 +42,7 @@ func init() {
 	gob.Register(bson.M{})
 	gob.Register(bson.D{})
 	gob.Register([]bson.M{})
+	gob.Register(time.Time{})
 
 	var config query.BenchmarkRunnerConfig
 	config.AddToFlagSet(pflag.CommandLine)

--- a/query/mongo.go
+++ b/query/mongo.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 // Mongo encodes a Mongo request. This will be serialized for use
@@ -14,6 +15,7 @@ type Mongo struct {
 	HumanDescription []byte
 	CollectionName   []byte
 	BsonDoc          []bson.M
+	Opts             *options.AggregateOptions
 	id               uint64
 }
 
@@ -25,6 +27,7 @@ var MongoPool = sync.Pool{
 			HumanDescription: []byte{},
 			CollectionName:   []byte{},
 			BsonDoc:          []bson.M{},
+			Opts:             &options.AggregateOptions{},
 		}
 	},
 }


### PR DESCRIPTION
Preliminary benchmarks: https://docs.google.com/spreadsheets/d/1hg2MHacoFwKz2648-58E-ppQU44FlLwAuuGpvmOYbOE/edit?usp=sharing

We are running the generated queries on three configurations:
1. Naive - one document per event
2. Recommended - manual bucketing
3. Naive, backed by time-series collection

An example of a document in the "naive" configuration:
```
{
	"_id" : ObjectId("6050d5e0e9cfbf47a4853238"),
	"measurement" : "cpu",
	"usage_user" : 58,
	"usage_idle" : 23
	"usage_guest" : 81,
	...
	"time" : ISODate("2016-01-01T00:00:10Z"),
	"tags" : {
		"hostname" : "host_0",
		"region" : "eu-central-1",
		"datacenter" : "eu-central-1a",
		"arch" : "x86",
                ...
	}
}
```

A document in the "recommended" configuration:
```
{
	"_id" : ObjectId("6050eed2c58a2ebec5c93b9d"),
	"doc_id" : "day_host_0_20160101_00_cpu",
	"key_id" : "20160101_00",
	"measurement" : "cpu",
	"tags" : {
		"arch" : "x86",
		"region" : "eu-central-1",
		"datacenter" : "eu-central-1a",
		"hostname" : "host_0",
                ...
	},
	"events" : [
     		[
        		{
				"time" : NumberLong("1451609990000000000")
				"usage_user" : 36,
				"usage_irq" : 64,
				"usage_guest" : 97,
			},
			... // (59 elements elided)
    		],
    		... // (59 elements elided)
	 ]
}
```