### PR TITLE
Add secondary index for time-series and naive collections

### DIFF
--- a/cmd/tsbs_load_mongo/creator.go
+++ b/cmd/tsbs_load_mongo/creator.go
@@ -68,8 +68,15 @@ func (d *dbCreator) CreateDB(dbName string) error {
 		return fmt.Errorf("create collection err: %v", res.Err().Error())
 	}
 
-	if !documentPer {
-		model := []mongo.IndexModel{
+	var model []mongo.IndexModel
+	if documentPer {
+		model = []mongo.IndexModel{
+			{
+				Keys: bson.D{{"time", 1}, {"tags.hostname", 1}},
+			},
+		}
+	} else {
+		model = []mongo.IndexModel{
 			{
 				Keys: bson.D{{aggDocID, 1}},
 			},
@@ -77,11 +84,11 @@ func (d *dbCreator) CreateDB(dbName string) error {
 				Keys: bson.D{{aggKeyID, 1}, {"measurement", 1}, {"tags.hostname", 1}},
 			},
 		}
-		opts := options.CreateIndexes()
-		_, err := d.client.Database(dbName).Collection(collectionName).Indexes().CreateMany(context.Background(), model, opts)
-		if err != nil {
-			return fmt.Errorf("create indexes err: %v", err.Error())
-		}
+	}
+	opts := options.CreateIndexes()
+	_, err := d.client.Database(dbName).Collection(collectionName).Indexes().CreateMany(context.Background(), model, opts)
+	if err != nil {
+		return fmt.Errorf("create indexes err: %v", err.Error())
 	}
 
 	return nil


### PR DESCRIPTION
TSBS performance changes here: https://docs.google.com/spreadsheets/d/1ZIFlqsFySoo_S_rOEuXXFv72s4Ob_V8d4V3Jkazfje8/edit?usp=sharing

After the addition of a `{time: 1, tags.hostname: 1}` index, each TSBS query will result in an IXSCAN + FETCH instead of the previous bounded COLLSCAN with the clustered _id index. For queries that can build narrow index bounds (ex. single-groupby-1-1-1, high-cpu-1) performance speed increases with the secondary index, however queries that don't build narrow bounds (ex. single-groupby-1-8-1, high-cpu-all) experience a performance regression since fetching many records is more expensive than a bounded collection scan. Currently the query planner will choose an indexed solution (when it exists) over a bounded collection scan every time, I've filed a ticket to add the time-series collection scan plan to the multi-planning process to avoid the performance regressions in the latter cases: https://jira.mongodb.org/browse/SERVER-58276.

One additional note is that the `{time: 1, tags.hostname: 1}` index will greatly speed up the lastpoint type queries once the related query rewrite work is completed.