### PR TITLE
Restructure MongoDB lastpoint query

### DIFF
--- a/cmd/tsbs_run_queries_mongo/main.go
+++ b/cmd/tsbs_run_queries_mongo/main.go
@@ -92,7 +92,7 @@ func (p *processor) ProcessQuery(q query.Query, _ bool) ([]*query.Stat, error) {
 	mq := q.(*query.Mongo)
 	start := time.Now().UnixNano()
 
-	cursor, err := p.collection.Aggregate(context.Background(), mq.BsonDoc, mq.Opts)
+	cursor, err := p.collection.Aggregate(context.Background(), mq.BsonDoc)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/query/mongo.go
+++ b/query/mongo.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 // Mongo encodes a Mongo request. This will be serialized for use
@@ -15,7 +14,6 @@ type Mongo struct {
 	HumanDescription []byte
 	CollectionName   []byte
 	BsonDoc          []bson.M
-	Opts             *options.AggregateOptions
 	id               uint64
 }
 
@@ -27,7 +25,6 @@ var MongoPool = sync.Pool{
 			HumanDescription: []byte{},
 			CollectionName:   []byte{},
 			BsonDoc:          []bson.M{},
-			Opts:             &options.AggregateOptions{},
 		}
 	},
 }


### PR DESCRIPTION
The previous lastpoint query took around 42 seconds to run; this version takes 16 seconds - a 62% increase in performance speed!

After [SERVER-58134](https://jira.mongodb.org/browse/SERVER-58134) this version of the lastpoint query should be even faster, as the $lookup subpipeline will be able to use the `{time: 1, tags.hostname: 1}` index.